### PR TITLE
Added src\minecraft for DeclareRecipes, basic PluginMessage functions, ServerDifficulty, PlayerAbilities and HeldItemChange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-tokio = { version = "1.4", features = ["full"] } 
+tokio = { version = "1.4", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 bytes = "1"
 
@@ -20,3 +20,5 @@ chrono = "0.4"
 
 toml = "0.5"
 uuid = { version = "0.8", features = ["v3", "serde"] }
+
+hematite-nbt = "0.5.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::{
     io::ErrorKind,
-    ops::{Range, RangeInclusive},
+    ops::RangeInclusive,
 };
 
 use log::{error, info, warn};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ pub mod net;
 pub mod serde;
 pub mod server;
 pub mod world;
+pub mod minecraft;
 
-use log::{debug, info};
+use log::debug;
 use net::NetHandler;
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/src/minecraft/item.rs
+++ b/src/minecraft/item.rs
@@ -1,0 +1,9 @@
+use crate::serde::types::Varint;
+use nbt::Blob;
+
+pub struct Slot {
+    pub present: bool,
+    pub item_id: Option<Varint>,
+    pub item_count: Option<i8>,
+    pub nbt_tag: Option<Blob>,
+}

--- a/src/minecraft/mod.rs
+++ b/src/minecraft/mod.rs
@@ -1,0 +1,2 @@
+pub mod recipe;
+pub mod item;

--- a/src/minecraft/recipe.rs
+++ b/src/minecraft/recipe.rs
@@ -1,0 +1,87 @@
+use crate::serde::types::Varint;
+use crate::minecraft::item::Slot;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Recipe {
+    pub recipe_type: String,
+    pub id: String,
+    pub data: Option<RecipeData>
+}
+
+#[derive(Serialize)]
+pub enum RecipeData {
+    ShapelessRecipeData,
+    ShapedRecipeData,
+    CookingRecipeData,
+    StoneCuttingRecipeData,
+    SmithingRecipeData
+}
+
+/// * used for recipe_type:`crafting_shapeless`
+pub struct ShapelessRecipeData {
+    pub group: String,
+    pub ingredient_count: Varint,
+    pub ingredients: Vec<Ingredient>,
+    pub result: Slot,
+}
+
+/// * used for recipe_type: `crafting_shaped`
+pub struct ShapedRecipeData {
+    pub width: Varint,
+    pub height: Varint,
+    pub group: String,
+    pub ingredients: Vec<Ingredient>,
+    pub result: Slot,
+}
+
+/// * used for recipe_types:
+/// *    `smelting`
+/// *    `blasting`
+/// *    `smoking`
+/// *    `campfire_cooking`
+pub struct CookingRecipeData {
+    pub group: String,
+    pub ingredient: Ingredient,
+    pub result: Slot,
+    pub experience: f32,
+    pub cooking_time: Varint,
+}
+
+/// * used for recipe_type: `stonecutting`
+pub struct StoneCuttingRecipeData {
+    pub group: String,
+    pub ingredient: Ingredient,
+    pub result: Slot,
+}
+
+/// * used for recipe_type: `smithing`
+pub struct SmithingRecipeData {
+    pub base: Ingredient,
+    pub addition: Ingredient,
+    pub result: Slot,
+}
+
+// * NO RECIPE DATA FOR recipe_types:
+// *
+// *    `crafting_special_armordye`
+// *    `crafting_special_bookcloning`
+// *    `crafting_special_mapcloning`
+// *    `crafting_special_mapextending`
+// *    `crafting_special_firework_rocket`
+// *    `crafting_special_firework_star`
+// *    `crafting_special_firework_star_fade`
+// *    `crafting_special_repairitem`
+// *    `crafting_special_tippedarrow`
+// *    `crafting_special_bannerduplicate`
+// *    `crafting_special_banneraddpattern`
+// *    `crafting_special_shielddecoration`
+// *    `crafting_special_shulkerboxcoloring`
+// *    `crafting_special_suspiciousstew`
+// *
+
+
+pub struct Ingredient {
+    pub count: Varint,
+    pub items: Vec<Slot>,
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 
 use std::sync::Arc;
 
-use log::{debug, info};
+use log::debug;
 use tokio::{net::TcpListener, sync::Mutex};
 
 use crate::{config::Config, server::Server};

--- a/src/serde/packets/play/clientbound.rs
+++ b/src/serde/packets/play/clientbound.rs
@@ -3,6 +3,48 @@ use serde::Serialize;
 use uuid::Uuid;
 
 #[derive(Serialize)]
+pub struct PluginMessage {
+    pub channel: String,
+    pub data: Vec<i8>,
+}
+
+#[derive(Serialize)]
+pub struct ServerDifficulty {
+    pub difficulty: u8,
+    pub difficulty_locked: bool,
+}
+
+#[derive(Serialize, Copy, Clone)]
+pub struct PlayerAbilities {
+    pub flags: i8,
+    pub flying_speed: f32,
+    pub fov_modifier: f32,
+}
+
+impl Default for PlayerAbilities {
+    fn default() -> PlayerAbilities {
+        Self { flags: 0, flying_speed: 0.05, fov_modifier: 0.1 }
+    }
+}
+
+impl PlayerAbilities {
+    pub fn flag(invurnable: bool, flying: bool, allow_flying: bool, creative_mode: bool) -> i8 {
+        let mut flag: i8 = 0x00;
+        flag |= invurnable as i8;
+        flag |= (flying as i8) << 1;
+        flag |= (allow_flying as i8) << 2;
+        flag |= (creative_mode as i8) << 3;
+
+        flag
+    }
+}
+
+#[derive(Serialize)]
+pub struct HeldItemChange {
+    pub slot: i8,
+}
+
+#[derive(Serialize)]
 pub struct SpawnEntity {
     pub entity_id: Varint,
     pub object_uuid: Uuid,

--- a/src/serde/packets/play/clientbound.rs
+++ b/src/serde/packets/play/clientbound.rs
@@ -1,4 +1,5 @@
 use crate::serde::types::Varint;
+use crate::minecraft::recipe::Recipe;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -10,8 +11,16 @@ pub struct PluginMessage {
 
 #[derive(Serialize)]
 pub struct ServerDifficulty {
-    pub difficulty: u8,
+    pub difficulty: Difficulty,
     pub difficulty_locked: bool,
+}
+
+#[derive(Serialize)]
+pub enum Difficulty {
+    PEACEFUL = 0,
+    EASY = 1,
+    NORMAL = 2,
+    HARD = 3,
 }
 
 #[derive(Serialize, Copy, Clone)]
@@ -42,6 +51,12 @@ impl PlayerAbilities {
 #[derive(Serialize)]
 pub struct HeldItemChange {
     pub slot: i8,
+}
+
+#[derive(Serialize)]
+pub struct DeclareRecipes {
+    pub num_recipes: Varint,
+    pub recipes: Vec<Recipe>,
 }
 
 #[derive(Serialize)]

--- a/src/serde/packets/play/mod.rs
+++ b/src/serde/packets/play/mod.rs
@@ -3,8 +3,9 @@ use crate::server::Server;
 use crate::net::client::Client;
 use crate::net::error::NetError;
 use crate::serde::packets::play::clientbound::{
-    SpawnEntity, PluginMessage, ServerDifficulty, PlayerAbilities
+    SpawnEntity, PluginMessage, ServerDifficulty, Difficulty, DeclareRecipes
 };
+use crate::minecraft::recipe::Recipe;
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -13,7 +14,7 @@ use uuid::Uuid;
 pub mod clientbound;
 pub mod serverbound;
 
-
+/// * send plugin message to a specific `client` via a specific `plugin_channel`
 pub async fn send_plugin_message_to_client(
     mut client: Client,
     channel: String,
@@ -29,6 +30,7 @@ pub async fn send_plugin_message_to_client(
         .await
 }
 
+/// * broadcast plugin message to `all clients` on the server via a specific `plugin channel`
 pub async fn send_plugin_message_to_all_clients(
     server: Arc<Mutex<Server>>,
     channel: String,
@@ -46,9 +48,10 @@ pub async fn send_plugin_message_to_all_clients(
         .await
 }
 
+/// * set server difficulty
 pub async fn set_server_difficulty(
     server: Arc<Mutex<Server>>,
-    difficulty: u8,
+    difficulty: Difficulty,
     difficulty_locked: bool
 ) -> Result<(), NetError> {
     let difficulty_packet = ServerDifficulty {
@@ -63,7 +66,7 @@ pub async fn set_server_difficulty(
         .await
 }
 
-/// method for spawning an Entity
+/// * method for spawning an Entity
 pub async fn spawn_entity(
     server: Arc<Mutex<Server>>,
     entity_id: Varint,
@@ -97,11 +100,28 @@ pub async fn spawn_entity(
         .await
 }
 
+pub async fn declare_recipes(
+    mut client: Client,
+    num_recipes: Varint,
+    recipes: Vec<Recipe>
+) -> Result<(), NetError> {
+    let declare_recipes = DeclareRecipes {
+        num_recipes,
+        recipes
+    };
+
+    client
+        .send_packet(0x5A, declare_recipes)
+        .await
+}
+
+#[allow(unused_variables)]
 pub async fn spawn_experience_orb(
     server: Arc<Mutex<Server>>,
     entity_id: Varint,
     position: (f32, f32, f32),
     count: i16,
 ) {
+    // TODO: IMPLEMENT EXPERIENCE ORB SPAWING
     todo!("Implement Experience Orb Spawning");
 }

--- a/src/serde/packets/play/serverbound.rs
+++ b/src/serde/packets/play/serverbound.rs
@@ -22,3 +22,8 @@ pub enum MainHand {
     Left = 0,
     Right = 1,
 }
+
+pub struct PluginMessage {
+    pub channel: String,
+    pub data: Vec<i8>,
+}

--- a/src/server/player.rs
+++ b/src/server/player.rs
@@ -1,16 +1,29 @@
 use uuid::Uuid;
 
-use crate::{net::client::Client, serde::play::serverbound::ClientSettings};
+use crate::{
+    net::{
+        client::Client,
+        error::NetError
+    },
+    serde::play::{
+        serverbound::ClientSettings,
+        clientbound::{
+            HeldItemChange, PlayerAbilities
+        }
+    }
+};
 
 pub struct Player {
     client: Client,
     uuid: Uuid,
     client_settings: Option<ClientSettings>,
+    player_abilities: PlayerAbilities,
+    active_slot: i8,
 }
 
 impl Player {
     pub fn new(client: Client, uuid: Uuid) -> Self {
-        Self { client, uuid, client_settings: None }
+        Self { client, uuid, client_settings: None, active_slot: 0, player_abilities: PlayerAbilities::default() }
     }
 
     pub fn uuid(&self) -> &Uuid {
@@ -22,10 +35,29 @@ impl Player {
     }
 
     pub fn client_settings(&self) -> &Option<ClientSettings> {
-        &self.client_settings        
+        &self.client_settings
     }
 
     pub fn set_client_settings(&mut self, client_settings: ClientSettings) {
         self.client_settings = Some(client_settings);
+    }
+
+    pub async fn set_player_abilites(&mut self, player_abilities: PlayerAbilities) -> Result<(), NetError> {
+        self.player_abilities = player_abilities;
+
+        self.client_mut()
+            .send_packet(0x30, player_abilities)
+            .await
+    }
+
+    pub async fn set_active_slot(&mut self, slot: i8) -> Result<(), NetError> {
+        self.active_slot = slot;
+        let held_item_change = HeldItemChange {
+            slot
+        };
+
+        self.client_mut()
+            .send_packet(0x3F, held_item_change)
+            .await
     }
 }


### PR DESCRIPTION
### Added
Recipe and Item structs
```
src\minecraft
  |-- item.rs
  |-- mod.rs
  |-- recipe.rs
```


### `PluginMessage (clientbound)` functions implemented on basic level

- `PluginMessage (serverbound)` struct added

### `ServerDifficulty` packets can now be sent

- implemented `enum Difficulty`

### `PlayerAbilities` can now be set in _**src\server\player.rs**_

- `PlayerAbilites` now get stored in a `Player` struct, defined in `player.rs`
- `PlayerAbilities::default()` used when `Player::new()` is called
- Abilites can be changed width `set_player_abilities(...)` in `player,rs`

### `HeldItemChange` packets are now sendable

- `active_slot` stored in `Player` struct
- Slot can be changed with `set_active_slot(...)` in `player.rs`

### Readability Changes
- Removed some redundant `use` statements
- Added comments on some functions